### PR TITLE
feat: create dev environment [skip-ci]

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -1,0 +1,77 @@
+name: Main Build, Test, and Deploy
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  react_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '22.x'
+
+      - name: Install dependencies
+        run: |
+          npm install
+
+      - name: Lint React App
+        run: |
+          npm run lint
+
+      - name: Build React App
+        run: |
+          npm run build
+
+  docker_build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:${{ github.sha }}
+
+  bump_release_dev:
+    runs-on: ubuntu-latest
+    needs: [react_build, docker_build]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4 
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1 
+         
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}  
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}:${{ steps.extract_branch.outputs.branch }}-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 node:22.5-alpine
+FROM --platform=linux/amd64 node:20-alpine
 
 WORKDIR /surim_site
 

--- a/cron/check_docker_hub_dev.sh
+++ b/cron/check_docker_hub_dev.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Arguments: DOCKER_HUB_USERNAME, IMAGE_NAME, CONTAINER_NAME
+# For DEV environment
+DOCKER_HUB_USERNAME=$1
+IMAGE_NAME=$2
+CONTAINER_NAME=$3
+
+# Get the list of tags for the specified image
+TAGS=$(curl -s -H "Accept: application/json" https://hub.docker.com/v2/repositories/${DOCKER_HUB_USERNAME}/${IMAGE_NAME}/tags)
+
+# Filter the tags to get the latest one with "dev" in the end
+LATEST_DEV_TAG=$(echo "$TAGS" | jq -r '.results[] | .name' | grep -E 'dev$' | sort -V | tail -1)
+
+# Check if latest tag has been pulled
+if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep -q "${DOCKER_HUB_USERNAME}/${IMAGE_NAME}:${LATEST_DEV_TAG}"; then
+# Pull the latest image
+  docker pull ${DOCKER_HUB_USERNAME}/${IMAGE_NAME}:${LATEST_DEV_TAG}
+
+  # If the container is running, kill it
+  if docker ps -q -f name=${CONTAINER_NAME} > /dev/null; then
+    # If the container exists, kill it
+    docker kill ${CONTAINER_NAME}
+    docker container rm ${CONTAINER_NAME}
+  fi
+
+  # Run the newly pulled image
+  docker run -d -p 4000:4000 --restart=always --name ${CONTAINER_NAME} ${DOCKER_HUB_USERNAME}/${IMAGE_NAME}:${LATEST_DEV_TAG} npm run dev
+fi

--- a/cron/check_docker_hub_prod.sh
+++ b/cron/check_docker_hub_prod.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Arguments: DOCKER_HUB_USERNAME, IMAGE_NAME, CONTAINER_NAME
-# TODO: add support for dev env
+# For PROD environment
 DOCKER_HUB_USERNAME=$1
 IMAGE_NAME=$2
 CONTAINER_NAME=$3
@@ -14,9 +14,6 @@ TAGS=$(echo "${TAGS}" | jq -r '.results[] | .name + " " + .last_updated')
 
 # Filter out tags that contain "dev" and sort the remaining tags by the last_pushed_at timestamp
 LATEST_TAG=$(echo "${TAGS}" | grep -v "dev" | sort -r -k 2 -t ' ' | head -1 | cut -d ' ' -f 1)
-
-# Filter tags that contain "dev" and sort them by the last_pushed_at timestamp
-DEV_TAG=$(echo "${TAGS}" | grep "dev" | sort -r -k 2 -t ' ' | head -1 | cut -d ' ' -f 1)
 
 # Check if latest tag has been pulled
 if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep -q "${DOCKER_HUB_USERNAME}/${IMAGE_NAME}:${LATEST_TAG}"; then

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 4000",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 3000",
     "lint": "next lint"
   },
   "dependencies": {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -79,6 +79,15 @@ resource "cloudflare_record" "surim_site" {
     proxied = true
 }
 
+resource "cloudflare_record" "surimkim_com_wildcard" {
+  zone_id = data.cloudflare_zone.surim_site.id
+  name    = "*"
+  value   = "${aws_instance.surim_site.public_ip}"
+  type    = "A"
+  ttl     = 1
+  proxied = true
+}
+
 resource "cloudflare_record" "surim_site_www" {
     zone_id = data.cloudflare_zone.surim_site.id
     name = "www"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "ec2_public_ip" {
+    value = aws_instance.surim_site.public_ip
+    description = "The public IP address of the EC2 instance"
+}


### PR DESCRIPTION
Create dev environment for site.

Access via `dev.surimkim.com`

Changes:

- Renamed `check_docker_hub.sh` to `check_docker_hub_prod`
- Specified ports for next.js `dev` and `start` commands in `package.json`
- Updated `README.md` pertaining to dev environment, esp cronjobs and https nginx proxy setup

Additions:
- Added `dev.yaml` github actions workflow to run on PR
- Added `check_docker_hub_dev.sh` to `cron` to pull dev images
- Added new wildcard cloudflare record in `terraform/main.tf` to support `dev.surimkim.com`